### PR TITLE
Ändra responstyp för GET /organisation/{organisation_id}

### DIFF
--- a/metria/metria-api.yaml
+++ b/metria/metria-api.yaml
@@ -113,9 +113,7 @@ paths:
         '200':
           description: Returnerar statusinformation om organisationen.
           schema:
-            type: array
-            items:
-              $ref: '#/definitions/Organisation'
+            $ref: '#/definitions/Organisation'
         '401':
           description: (Unauthorized). Användaren är inte inloggad (autentiserad).
           schema:


### PR DESCRIPTION
Hej!

Tror responstypen för anrop av specifik organisation blivit fel. Anropet borde inte returnera en array.